### PR TITLE
Changed directory_name in gen to use pkgutils

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -5,6 +5,7 @@ import re
 import json
 from optparse import OptionParser
 from string import Template
+from tools import pkgutils
 
 SPEC_IN = 'repo.spec.in'
 SPEC_FMT = 'SPECS/%s.spec'
@@ -25,10 +26,7 @@ def get_dist():
 
 
 def get_directory_name():
-    dist = platform.dist()
-    version = dist[1]
-    dist = "%s-%s" % (platform.dist()[0].lower(), version)
-    return "%s-%s" % (dist, platform.machine().lower())
+    return pkgutils.pkg_dir()
 
 
 def generate_spec(options, tmpl, channel):


### PR DESCRIPTION
On CentOS where the release was reported as:

```
> cat /etc/centos-release
CentOS Linux release 8.1.1911 (Core)
```

the `directory_name` template variable would resolve to `centos-8.1.1911-x86_64` because `package.dist()` returns `('centos', '8.1.1911', 'Core')`. It was expected to be `centos-8-x86_64`

The buildbot process is already using the `pkg_dir` function in `tools/pkgutils.py` via calls to `tools/get_platform.py` [here](https://github.com/racker/buildbot/blob/acbee830b620c5ff122decacb93c5999b9219961/master_agentbuild_cm/meta.py#L28) and that function was performing all the extra logic to trim the CentOS/Redhat release number. (FYI that platform lookup gets used [further down in the build definition](https://github.com/racker/buildbot/blob/acbee830b620c5ff122decacb93c5999b9219961/master_agentbuild_cm/meta.py#L61).)

So the fix leverages the same function to consistently arrive at the expected package directory, which is really what it should have done the whole time since the URL in the repo spec needs to match the published directory name.