### PR TITLE
Removed debian codename mapping starting with buster/10

### DIFF
--- a/tools/pkgutils.py
+++ b/tools/pkgutils.py
@@ -64,9 +64,8 @@ def pkg_dir():
                 dist = [dist[0], 'jessie']
             elif dist[1][0] == '9':
                 dist = [dist[0], 'stretch']
-            else:
-                dist = [dist[0], 'undefined']
-        # Lower case everyting (looking at you Ubuntu)
+            # leave it numerical to avoid forever maintaining this list
+        # Lower case everything (looking at you Ubuntu)
         dist = tuple([x.lower() for x in dist])
 
         # Treat all redhat 5.* versions the same


### PR DESCRIPTION
Apparently Debian 10 meta package upload was previously broken since the links provided here don't resolve properly

https://meta.packages.cloudmonitoring.rackspace.com/#debian-buster-10

Since this has to be changed every time there's a commit in this repo, it is very annoying to have to bump the meta version each time we have a new debian release:

https://github.com/racker/ele-agent-repo-distribution/blob/4522a006c99ced666e8ba99e145b2433e94924aa/sync-repo-package.json#L16

## TODO

Change the links here to reference "debian-10" instead of "debian-buster"

https://github.com/racker/ele-agent-repo-distribution/blame/1827de5ecc1d51d4f9c1dbb386a92c7a175153b6/static/meta/index.md#L263-L266