### PR TITLE
Fix RPM build spec file creation

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -156,6 +156,7 @@ if __name__ == '__main__':
     if DIST in RPM:
         with open(SPEC_IN, 'r', encoding='utf-8') as SPEC_TMPL:
             for channel in CHANNELS:
+                SPEC_TMPL.seek(0)
                 generate_spec(CONFIG, SPEC_TMPL.read(), channel)
 
     if DIST in DEB:


### PR DESCRIPTION
For RPM build we were getting the issue while craeting teh spec files. Issue is when we pass the channels in a loop after reading the template, for the first pass of template it reads file and update teh content but for further channel file read reached EOF. So it had no content to read. To fix this, we need to reset the file pointer to the beginning of file.